### PR TITLE
Ensure OrmConfig Builder validates database name

### DIFF
--- a/dcache/src/main/java/dora/db/OrmConfig.kt
+++ b/dcache/src/main/java/dora/db/OrmConfig.kt
@@ -35,6 +35,9 @@ class OrmConfig private constructor(builder: Builder) {
         }
 
         fun build(): OrmConfig {
+            if (!::databaseName.isInitialized) {
+                throw IllegalStateException("Database name must be initialized")
+            }
             return OrmConfig(this)
         }
     }


### PR DESCRIPTION
## Summary
- check that `databaseName` is initialized before creating `OrmConfig`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a380fecdcc8330a54da20b0d766fab