### PR TITLE
fix: correct URLEncoder detection in UrlEncoderUtils

### DIFF
--- a/dcache/src/main/java/dora/http/log/UrlEncoderUtils.kt
+++ b/dcache/src/main/java/dora/http/log/UrlEncoderUtils.kt
@@ -28,8 +28,6 @@ class UrlEncoderUtils private constructor() {
                     if (isValidHexChar(c1) && isValidHexChar(c2)) {
                         encode = true
                         break
-                    } else {
-                        break
                     }
                 }
             }

--- a/dcache/src/test/java/dora/http/log/UrlEncoderUtilsTest.kt
+++ b/dcache/src/test/java/dora/http/log/UrlEncoderUtilsTest.kt
@@ -1,0 +1,19 @@
+package dora.http.log
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UrlEncoderUtilsTest {
+
+    @Test
+    fun hasUrlEncoded_detectsValidSequences() {
+        assertTrue(UrlEncoderUtils.hasUrlEncoded("abc%20def"))
+    }
+
+    @Test
+    fun hasUrlEncoded_ignoresInvalidSequences() {
+        assertTrue(UrlEncoderUtils.hasUrlEncoded("abc%2G%20def"))
+        assertFalse(UrlEncoderUtils.hasUrlEncoded("abc%2Gdef"))
+    }
+}


### PR DESCRIPTION
## Summary
- fix UrlEncoderUtils to keep scanning after invalid percent sequences
- add unit tests for URL encoding detection

## Testing
- `./gradlew :dcache:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e8aeee108330b1b923a8872668f5