### PR TITLE
feat: add fluent API to FlowableChain

### DIFF
--- a/dcache/src/main/java/dora/cache/FlowableChain.kt
+++ b/dcache/src/main/java/dora/cache/FlowableChain.kt
@@ -7,18 +7,39 @@ class FlowableChain<T> {
     private var lastFlowable: Flowable<T> = Flowable.empty()
     private var lastListFlowable: Flowable<MutableList<T>> = Flowable.empty()
 
-    fun add(next: Flowable<T>): Flowable<T> {
+    /**
+     * Add a [Flowable] to the chain and return the chain itself so calls can be
+     * chained fluently.
+     */
+    fun add(next: Flowable<T>): FlowableChain<T> {
         lastFlowable = lastFlowable.concatWith(next)
-        return lastFlowable
+        return this
     }
 
-    fun addList(next: Flowable<MutableList<T>>): Flowable<MutableList<T>> {
+    /**
+     * Add a list [Flowable] to the chain and return the chain for fluent calls.
+     */
+    fun addList(next: Flowable<MutableList<T>>): FlowableChain<T> {
         lastListFlowable = lastListFlowable.concatWith(next)
-        return lastListFlowable
+        return this
     }
 
-    fun reset() {
+    /**
+     * Get the concatenated [Flowable] in the order items were added.
+     */
+    fun flowable(): Flowable<T> = lastFlowable
+
+    /**
+     * Get the concatenated list [Flowable].
+     */
+    fun listFlowable(): Flowable<MutableList<T>> = lastListFlowable
+
+    /**
+     * Clears the current chain and returns itself for further configuration.
+     */
+    fun reset(): FlowableChain<T> {
         lastFlowable = Flowable.empty()
         lastListFlowable = Flowable.empty()
+        return this
     }
 }


### PR DESCRIPTION
## Summary
- make FlowableChain's add functions return the chain for easier chaining
- expose methods to retrieve the concatenated flowables

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e1f72dd083308ff5cb09ebe87efb