### PR TITLE
Fix backpressure strategy and add thread safety

### DIFF
--- a/dcache/src/main/java/dora/cache/repository/BaseRepository.kt
+++ b/dcache/src/main/java/dora/cache/repository/BaseRepository.kt
@@ -92,6 +92,7 @@ abstract class BaseRepository<M, F : CacheHolderFactory<M>>(val context: Context
         protected get() = false
     protected val MClass: Class<M>
 
+    @Volatile
     protected var lastRequestKey: Any? = null
 
     protected var requestQueue: FlowableChain<M> = FlowableChain<M>()
@@ -487,49 +488,45 @@ abstract class BaseRepository<M, F : CacheHolderFactory<M>>(val context: Context
         val currentKey: Any = (this as? IRequestParam)?.comparisonKey()
             ?: getRequestParams().joinToString("|") { it.toString() }
         val repo = this.javaClass.getAnnotation(Repository::class.java)
+        val strategy = synchronized(this) {
+            val dropLatest = currentKey == lastRequestKey && repo?.dropLatestOnSameParams == true
+            val dropPrevious = currentKey != lastRequestKey && repo?.dropPreviousOnDifferentParams == true
+            lastRequestKey = currentKey
+            when {
+                dropLatest -> BackpressureStrategy.DROP
+                dropPrevious -> BackpressureStrategy.LATEST
+                else -> BackpressureStrategy.BUFFER
+            }
+        }
         return observable
             .distinctUntilChanged { old, new ->
                 val oldKey = (old as? IRequestParam)?.comparisonKey() ?: old.toString()
                 val newKey = (new as? IRequestParam)?.comparisonKey() ?: new.toString()
                 oldKey == newKey
             }
-            .toFlowable(BackpressureStrategy.BUFFER)
-            .let { fb ->
-                if (currentKey == lastRequestKey && repo?.dropLatestOnSameParams == true) {
-                    lastRequestKey = currentKey
-                    fb.onBackpressureDrop()
-                } else if (currentKey != lastRequestKey && repo?.dropPreviousOnDifferentParams == true) {
-                    lastRequestKey = currentKey
-                    fb.onBackpressureLatest()
-                } else {
-                    lastRequestKey = currentKey
-                    fb
-                }
-            }
+            .toFlowable(strategy)
     }
 
     protected fun backPressureList(observable: Observable<MutableList<M>>): Flowable<MutableList<M>> {
         val currentKey: Any = (this as? IRequestParam)?.comparisonKey()
             ?: getRequestParams().joinToString("|") { it.toString() }
         val repo = this.javaClass.getAnnotation(ListRepository::class.java)
+        val strategy = synchronized(this) {
+            val dropLatest = currentKey == lastRequestKey && repo?.dropLatestOnSameParams == true
+            val dropPrevious = currentKey != lastRequestKey && repo?.dropPreviousOnDifferentParams == true
+            lastRequestKey = currentKey
+            when {
+                dropLatest -> BackpressureStrategy.DROP
+                dropPrevious -> BackpressureStrategy.LATEST
+                else -> BackpressureStrategy.BUFFER
+            }
+        }
         return observable
             .distinctUntilChanged { old, new ->
                 val oldKey = (old as? IRequestParam)?.comparisonKey() ?: old.toString()
                 val newKey = (new as? IRequestParam)?.comparisonKey() ?: new.toString()
                 oldKey == newKey
             }
-            .toFlowable(BackpressureStrategy.BUFFER)
-            .let { fb ->
-                if (currentKey == lastRequestKey && repo?.dropLatestOnSameParams == true) {
-                    lastRequestKey = currentKey
-                    fb.onBackpressureDrop()
-                } else if (currentKey != lastRequestKey && repo?.dropPreviousOnDifferentParams == true) {
-                    lastRequestKey = currentKey
-                    fb.onBackpressureLatest()
-                } else {
-                    lastRequestKey = currentKey
-                    fb
-                }
-            }
+            .toFlowable(strategy)
     }
-}
+    }


### PR DESCRIPTION
## Summary
- ensure backpressure strategies use DROP or LATEST instead of BUFFER
- guard lastRequestKey with volatile and synchronized updates to avoid races

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eaa840848330bf7c9b6a60bdfe6c